### PR TITLE
Optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "clean": "rimraf dist",
+    "build": "NODE_ENV=production npm run clean && webpack -p",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "./node_modules/babel-cli/bin/babel-node.js .",
-    "webpack-dev-server": "webpack-dev-server --progress --color"
+    "start": "npm run build && ./node_modules/babel-cli/bin/babel-node.js .",
+    "webpack-dev-server": "webpack-dev-server --progress --color",
+    "serve": "npm run webpack-dev-server"
   },
   "repository": {
     "type": "git",
@@ -19,20 +22,6 @@
   },
   "homepage": "https://github.com/rjbernaldo/self-serve-app#readme",
   "dependencies": {
-    "babel-cli": "^6.23.0",
-    "babel-core": "^6.23.1",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.1.11",
-    "babel-preset-es2015": "^6.22.0",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-2": "^6.22.0",
-    "css-loader": "^0.26.2",
-    "react-hot-loader": "^1.3.1",
-    "style-loader": "^0.13.2",
-    "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.4.1",
-    "babel-loader": "^6.3.2",
-    "babel-runtime": "^6.23.0",
     "body-parser": "^1.17.1",
     "dotenv": "^4.0.0",
     "express": "^4.15.0",
@@ -40,13 +29,28 @@
     "isomorphic-fetch": "^2.2.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-hot-loader": "^1.3.1",
     "react-redux": "^5.0.3",
     "react-router": "^3.0.2",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
-    "routes": "^2.1.0",
+    "routes": "^2.1.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.24.1",
+    "babel-loader": "^6.4.1",
+    "babel-preset-env": "^1.4.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1",
+    "css-loader": "^0.26.4",
+    "html-webpack-plugin": "^2.28.0",
+    "react-hot-loader": "^1.3.1",
+    "rimraf": "^2.6.1",
+    "style-loader": "^0.13.2",
+    "webpack": "^2.4.1",
     "webpack-dev-middleware": "^1.10.1",
+    "webpack-dev-server": "^2.4.2",
     "webpack-hot-middleware": "^2.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf dist",
     "build": "NODE_ENV=production npm run clean && webpack -p",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npm run build && ./node_modules/babel-cli/bin/babel-node.js .",
+    "start": "NODE_ENV=production npm run build && ./node_modules/babel-cli/bin/babel-node.js .",
     "webpack-dev-server": "webpack-dev-server --progress --color",
     "serve": "npm run webpack-dev-server"
   },

--- a/server.js
+++ b/server.js
@@ -50,8 +50,16 @@ app.use([
     })
 })
 
-app.use(webpackDevMiddleware(compiler))
-app.use(webpackHotMiddleware(compiler))
+if (process.env.NODE_ENV !== 'production') {
+  const webpackMiddleWare = require('webpack-dev-middleware');
+  const webpack = require('webpack');
+  const webpackConfig = require('./webpack.config.js');
+
+  app.use(webpackMiddleWare(webpack(webpackConfig)));
+} else {
+  app.use(express.static('dist'));
+}
+
 app.use('/', (req, res) => {
   const reducer = combineReducers(reducers)
   const store = createStore(reducer)
@@ -81,6 +89,8 @@ app.use('/', (req, res) => {
         </head>
         <body>
           <div id="app"><div>${componentHTML}</div></div>
+          <script type="application/javascript" src="/manifest.js"></script>
+          <script type="application/javascript" src="/vendor.js"></script>
           <script type="application/javascript" src="/bundle.js"></script>
           <script type="application/javascript">
             window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,28 @@
 var path = require('path')
 var webpack = require('webpack')
 
+const VENDOR_LIBS = [
+  'body-parser',
+  'history',
+  'isomorphic-fetch',
+  'react',
+  'react-dom',
+  'react-redux',
+  'react-router',
+  'redux',
+  'redux-thunk',
+  'routes'
+];
+
 module.exports = {
-  entry: [
-    // 'webpack-dev-server/client?http://127.0.0.1:8080/',
-    // 'webpack/hot/only-dev-server',
-    'webpack-hot-middleware/client',
-    './client'
-  ],
+  entry: {
+    webpackhotmiddleware: 'webpack-hot-middleware/client',
+    bundle: './client',
+    vendor: VENDOR_LIBS
+  },
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js'
+    filename: '[name].js'
   },
   module: {
     rules: [
@@ -28,6 +40,12 @@ module.exports = {
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.optimize.CommonsChunkPlugin({
+      names: ['vendor', 'manifest']
+    }),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    })
   ],
   devtool: 'inline-source-map',
   devServer: {


### PR DESCRIPTION
1. Separating javascript assets into multiple files:
```
 Asset     Size  Chunks                    Chunk Names
              vendor.js  6.16 MB       0  [emitted]  [big]  vendor
              bundle.js   610 kB       1  [emitted]  [big]  bundle
webpackhotmiddleware.js  34.3 kB       2  [emitted]         webpackhotmiddleware
            manifest.js  73.7 kB       3  [emitted]         manifest
```
bundle.js contains all of our code, vendor.js contains all of the vendor library. Each of these JS will be cached individually. Changes to our code will only change the bundle.js.

2. Cleaning up dependencies
3. Production mode, removing webpack-dev-server and webpack-hot-middleware during production mode and just using node and the built assets, improving performance.

npm start -> will build the assets into production mode and launch the node server while serving the built assets
npm run serve/npm run webpack-dev-server -> will still load it on development mode with hot reloading
